### PR TITLE
Set default for advertise_public_ips and use packages.vectorized.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please refer to each cloud's readme for more information: [AWS](aws/readme.md), 
 
 Before running these steps, verify that the `hosts.ini` file contains the correct information for your infrastructure. This will be automatically populated if using the terraform steps above.
         
-1. `ansible-playbook --private-key <your_private_key> -i hosts.ini -v ansible/playbooks/provision-node.yml -e redpanda_packagecloud_token=<your_token_here>`
+1. `ansible-playbook --private-key <your_private_key> -i hosts.ini -v ansible/playbooks/provision-node.yml`
 
   Available Ansible variables:
 

--- a/ansible/playbooks/install-redpanda.yml
+++ b/ansible/playbooks/install-redpanda.yml
@@ -3,14 +3,14 @@
   tasks:
   - name: add the redpanda repo
     shell: |
-      curl -s https://{{redpanda_packagecloud_token}}:@packagecloud.io/install/repositories/vectorizedio/v/script.deb.sh | sudo bash
+      curl -1sLf https://packages.vectorized.io/sMIXnoa7DK12JW4A/redpanda/cfg/setup/bash.deb.sh | sudo -E bash
     args:
       warn: no
     when: ansible_os_family == 'Debian'
   
   - name: add the redpanda repo
     shell: |
-      curl -s https://{{redpanda_packagecloud_token}}:@packagecloud.io/install/repositories/vectorizedio/v/script.rpm.sh | sudo bash
+      curl -1sLf https://packages.vectorized.io/sMIXnoa7DK12JW4A/redpanda/cfg/setup/bash.rpm.sh | sudo -E bash
     args:
       warn: no
     when: ansible_os_family == 'RedHat'

--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -11,12 +11,12 @@
       - restart redpanda-tuner
       - restart redpanda
     vars:
-      seed_private_ip: '{{ hostvars[groups["redpanda"][0]].private_ip }}'
+      use_public_ips: "{{ advertise_public_ips | default(false, true) }}"
     shell: |
       rpk config set cluster_id 'redpanda'
       rpk config set organization 'redpanda-test'
       rpk config set redpanda.advertised_kafka_api '{
-      {% if advertise_public_ips %}
+      {% if use_public_ips %}
         address: {{ inventory_hostname }},
       {% else %}
         address: {{ hostvars[inventory_hostname].private_ip }},
@@ -27,7 +27,7 @@
         address: {{ hostvars[inventory_hostname].private_ip }},
         port: 33145
       }' --format yaml
-      rpk mode production
+      sudo rpk mode production
 
       {% if hostvars[groups['redpanda'][0]].id == hostvars[inventory_hostname].id %}
       sudo rpk config bootstrap \
@@ -39,8 +39,9 @@
       sudo rpk config bootstrap \
         --id {{ hostvars[inventory_hostname].id }} \
         --self {{ hostvars[inventory_hostname].private_ip }} \
-        --ips {{ seed_private_ip }}
+        --ips {{ groups["redpanda"] | map('extract', hostvars) | map(attribute='private_ip') | join(',') }}
       {% endif %}
+
 
   handlers:
   - name: restart redpanda-tuner


### PR DESCRIPTION
There was no default for advertise_public_ips, so it would fail unless
the user specified this parameter. Also updated to use the new package
repo and drop the requirement for a token.