### PR TITLE
gcp: fix for GCP terraform module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sw?
 */**/.terraform
 */**/*.tfstate*
+*/**/*.lock*.hcl
 ansible/playbooks/grafana_dashboards/redpanda-grafana.json

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ cluster on AWS or GCP.
 
 * Install terraform in your preferred way https://www.terraform.io/downloads.html
 * Install Ansible https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
+* Depending on your system, you might need to install some python packages (e.g. `selinux` or `jmespath`). Ansible will throw an error with the expected python packages, both on local and remote machines.
 * `ansible-galaxy install -r ansible/requirements.yml` to gather ansible requirements
 
 ## Usage

--- a/ansible/playbooks/install-node-deps.yml
+++ b/ansible/playbooks/install-node-deps.yml
@@ -1,7 +1,7 @@
 - hosts: redpanda
   roles:
-  - cloudalchemy.node-exporter
-  
+  - cloudalchemy.node_exporter
+
   tasks:
 
   - name: amazon setup

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,4 +1,4 @@
 - src: mrlesmithjr.mdadm
 - src: cloudalchemy.prometheus
 - src: cloudalchemy.grafana
-- src: cloudalchemy.node-exporter
+- src: cloudalchemy.node_exporter

--- a/gcp/cluster.tf
+++ b/gcp/cluster.tf
@@ -7,7 +7,7 @@ provider "google" {
 resource "google_compute_instance" "redpanda" {
   count        = var.nodes
   name         = "rp-node-${count.index}"
-  tags         = ["rp-node"]
+  tags         = ["rp-cluster"]
   machine_type = var.machine_type
 
   metadata = {
@@ -41,7 +41,7 @@ KEYS
 resource "google_compute_instance" "monitor" {
   count        = 1
   name         = "rp-monitor"
-  tags         = ["rp-monitoring"]
+  tags         = ["rp-cluster"]
   machine_type = var.machine_type
 
   metadata = {

--- a/gcp/cluster.tf
+++ b/gcp/cluster.tf
@@ -1,6 +1,5 @@
 provider "google" {
-  credentials = file(pathexpand("~/.gcp.json"))
-  project     = "vectorized"
+  project     = var.project_name
   region      = var.region
   zone        = "${var.region}-${var.zone}"
 }

--- a/gcp/cluster.tf
+++ b/gcp/cluster.tf
@@ -38,9 +38,9 @@ KEYS
 
 }
 
-resource "google_compute_instance" "prometheus" {
-  count        = var.enable_monitoring ? 1 : 0
-  name         = "rp-monitoring"
+resource "google_compute_instance" "monitor" {
+  count        = 1
+  name         = "rp-monitor"
   tags         = ["rp-monitoring"]
   machine_type = var.machine_type
 
@@ -72,12 +72,11 @@ KEYS
 resource "local_file" "hosts_ini" {
   content = templatefile("${path.module}/../templates/hosts_ini.tpl",
     {
-      redpanda_public_ips   = google_compute_instance.redpanda.*.network_interface.0.access_config.0.nat_ip
-      redpanda_private_ips  = google_compute_instance.redpanda.*.network_interface.0.network_ip
-      prometheus_public_ip  = var.enable_monitoring ? google_compute_instance.prometheus[0].network_interface.0.access_config.0.nat_ip : ""
-      prometheus_private_ip = var.enable_monitoring ? google_compute_instance.prometheus[0].network_interface.0.network_ip : ""
-      ssh_user              = var.ssh_user
-      enable_monitoring     = var.enable_monitoring
+      redpanda_public_ips  = google_compute_instance.redpanda.*.network_interface.0.access_config.0.nat_ip
+      redpanda_private_ips = google_compute_instance.redpanda.*.network_interface.0.network_ip
+      monitor_public_ip    = google_compute_instance.monitor[0].network_interface.0.access_config.0.nat_ip
+      monitor_private_ip   = google_compute_instance.monitor[0].network_interface.0.network_ip
+      ssh_user             = var.ssh_user
     }
   )
   filename = "${path.module}/../hosts.ini"

--- a/gcp/readme.md
+++ b/gcp/readme.md
@@ -3,16 +3,21 @@
 This Terraform module will deploy VMs on GCP Compute Engine.
 
 **Prerequisites:**
+
 - An existing subnet to deploy the VMs into. The subnet's attached firewall should allow inbound traffic on ports 22, 3000, 8888, 8889, 9090, 9092, 9644 and 33145. This module adds the `rp-node` tag to the deployed VMs, which can be used as the target tag for the firewall rule.
+
+- The module assumes credentials for GCP have been configured using 
+  [User Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default). This can be done by executing `gcloud auth application-default login`, after which a JSON file is generated that the GCP provider can automatically find. Consult the [GCP provider documentation for other alternatives](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference).
 
 After completing these steps, please follow the required steps in the [project readme](../README.md) to deploy Redpanda to the new VMs.
 
 1. `terraform init`
 2. `terraform apply` to create the resources on AWS.
     - Supported configuration variables (See `vars.tf`):
+        - `project_name` (required): The name of the project on GCP to use.
+        - `subnet`: The name of an existing subnet to deploy the infrastructure on.
         - `region` (default: `us-west-1`): The region to deploy the infrastructure on.
         - `zone` (default: `a`): The region's zone to deploy the infrastructure on.
-        - `subnet`: The name of an existing subnet to deploy the infrastructure on.
         - `nodes` (default: `1`): The number of nodes to base the cluster on. Keep in mind that one node is used as a monitoring node.
         - `disks` (default: `1`): The number of **local** disks to deploy on each machine
         - `image` (default: `ubuntu-os-cloud/ubuntu-1804-lts`): The OS image running on the VMs.
@@ -20,4 +25,4 @@ After completing these steps, please follow the required steps in the [project r
         - `public_key_path`: Provide the path to the public key of the keypair used to access the nodes.
         - `ssh_user`: The ssh user. Must match the one in the public ssh key's comments.
 
-  Example: `terraform apply -var nodes=3 -var subnet=redpanda-cluster-subnet -var public_key_path=~/.ssh/id_rsa.pub -var ssh_user=$USER`
+  Example: `terraform apply -var nodes=3 -var project_name=myproject -var subnet=redpanda-cluster-subnet -var public_key_path=~/.ssh/id_rsa.pub -var ssh_user=$USER`

--- a/gcp/readme.md
+++ b/gcp/readme.md
@@ -4,7 +4,7 @@ This Terraform module will deploy VMs on GCP Compute Engine.
 
 **Prerequisites:**
 
-- An existing subnet to deploy the VMs into. The subnet's attached firewall should allow inbound traffic on ports 22, 3000, 8888, 8889, 9090, 9092, 9644 and 33145. This module adds the `rp-node` tag to the deployed VMs, which can be used as the target tag for the firewall rule.
+- An existing subnet to deploy the VMs into. The subnet's attached firewall should allow inbound traffic on ports 22, 3000, 8888, 8889, 9090, 9092, 9644 and 33145. This module adds the `rp-cluster` tag to the deployed VMs, which can be used as the target tag for the firewall rule.
 
 - The module assumes credentials for GCP have been configured using 
   [User Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default). This can be done by executing `gcloud auth application-default login`, after which a JSON file is generated that the Terraform GCP provider can automatically find. Consult the [GCP provider documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference) for other alternatives.

--- a/gcp/readme.md
+++ b/gcp/readme.md
@@ -7,7 +7,7 @@ This Terraform module will deploy VMs on GCP Compute Engine.
 - An existing subnet to deploy the VMs into. The subnet's attached firewall should allow inbound traffic on ports 22, 3000, 8888, 8889, 9090, 9092, 9644 and 33145. This module adds the `rp-node` tag to the deployed VMs, which can be used as the target tag for the firewall rule.
 
 - The module assumes credentials for GCP have been configured using 
-  [User Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default). This can be done by executing `gcloud auth application-default login`, after which a JSON file is generated that the GCP provider can automatically find. Consult the [GCP provider documentation for other alternatives](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference).
+  [User Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default). This can be done by executing `gcloud auth application-default login`, after which a JSON file is generated that the Terraform GCP provider can automatically find. Consult the [GCP provider documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference) for other alternatives.
 
 After completing these steps, please follow the required steps in the [project readme](../README.md) to deploy Redpanda to the new VMs.
 
@@ -15,7 +15,7 @@ After completing these steps, please follow the required steps in the [project r
 2. `terraform apply` to create the resources on AWS.
     - Supported configuration variables (See `vars.tf`):
         - `project_name` (required): The name of the project on GCP to use.
-        - `subnet`: The name of an existing subnet to deploy the infrastructure on.
+        - `subnet` (required): The name of an existing subnet to deploy the infrastructure on.
         - `region` (default: `us-west-1`): The region to deploy the infrastructure on.
         - `zone` (default: `a`): The region's zone to deploy the infrastructure on.
         - `nodes` (default: `1`): The number of nodes to base the cluster on. Keep in mind that one node is used as a monitoring node.

--- a/gcp/vars.tf
+++ b/gcp/vars.tf
@@ -11,6 +11,10 @@ variable "subnet" {
   description = "The name of the existing subnet where the machines will be deployed"
 }
 
+variable "project_name" {
+  description = "The project name on GCP."
+}
+
 variable "nodes" {
   description = "The number of nodes to deploy."
   type        = number

--- a/gcp/vars.tf
+++ b/gcp/vars.tf
@@ -46,9 +46,3 @@ variable "public_key_path" {
 variable "ssh_user" {
   description = "The ssh user. Must match the one in the public ssh key's comments."
 }
-
-variable "enable_monitoring" {
-  description = "Setup a prometheus/grafana instance"
-  type        = bool
-  default     = true
-}

--- a/hosts.ini
+++ b/hosts.ini
@@ -1,6 +1,0 @@
-[redpanda]
-ip ansible_user=ssh_user ansible_become=True private_ip=pip id=0
-ip ansible_user=ssh_user ansible_become=True private_ip=pip id=1
-
-[monitor]
-ip ansible_user=ssh_user ansible_become=True private_ip=pip id=1

--- a/templates/hosts_ini.tpl
+++ b/templates/hosts_ini.tpl
@@ -3,7 +3,5 @@
 ${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${redpanda_private_ips[i]} id=${i}
 %{ endfor ~}
 
-%{~ if enable_monitoring == true ~}
 [monitor]
-${ prometheus_public_ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${ prometheus_private_ip } id=0
-%{~ endif ~}
+${ monitor_public_ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${ monitor_private_ip }


### PR DESCRIPTION
 - Removes hard-coded 'project_name' and 'credentials' from GCP
   configuration.

 - Introduces a 'project_name' variable to hold GCP project name.

 - Updates gcp/README with instructions on how to setup credentials and
   to document the new project_name variable