### PR TITLE
Fixed variables in AWS terraform script

### DIFF
--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -122,8 +122,8 @@ resource "local_file" "hosts_ini" {
     {
       redpanda_public_ips   = aws_instance.redpanda.*.public_ip
       redpanda_private_ips  = aws_instance.redpanda.*.private_ip
-      prometheus_public_ip  = var.enable_monitoring ? aws_instance.prometheus[0].public_ip : ""
-      prometheus_private_ip = var.enable_monitoring ? aws_instance.prometheus[0].private_ip : ""
+      monitor_public_ip  = var.enable_monitoring ? aws_instance.prometheus[0].public_ip : ""
+      monitor_private_ip = var.enable_monitoring ? aws_instance.prometheus[0].private_ip : ""
       ssh_user              = var.distro_ssh_user[var.distro]
       enable_monitoring     = var.enable_monitoring
     }


### PR DESCRIPTION
Changes in the GCP terraform script also included changes to the
host.ini template however, aws was not updated. This fixes this.