### PR TITLE
ansible: Only run playbooks when monitoring is enabled

### DIFF
--- a/templates/hosts_ini.tpl
+++ b/templates/hosts_ini.tpl
@@ -2,6 +2,8 @@
 %{ for i, ip in redpanda_public_ips ~}
 ${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${redpanda_private_ips[i]} id=${i}
 %{ endfor ~}
+%{ if enable_monitoring }
 
 [monitor]
 ${ monitor_public_ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${ monitor_private_ip }
+%{ endif }


### PR DESCRIPTION
Previously disabling monitoring resulted in a corrupted line ( without any IPs ) leading to errors when ansible tried to copy grafana dashboards onto the monitor node.

eg. 
```
[redpanda]
54.218.44.241 ansible_user=ubuntu ansible_become=True private_ip=172.31.54.48 id=0
34.219.213.230 ansible_user=ubuntu ansible_become=True private_ip=172.31.62.102 id=1
34.215.46.70 ansible_user=ubuntu ansible_become=True private_ip=172.31.55.29 id=2

[monitor]
 ansible_user=ubuntu ansible_become=True private_ip=
```
```
PLAY [monitor] *******************************************************************************************************************************************************************************
[WARNING]: Unhandled error in Python interpreter discovery for host ansible_user=ubuntu: Failed to connect to the host via ssh: ssh: Could not resolve hostname ansible_user=ubuntu: Name or
service not known

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
fatal: [ansible_user=ubuntu]: UNREACHABLE! => {"changed": false, "msg": "Data could not be sent to remote host \"ansible_user=ubuntu\". Make sure this host can be reached over ssh: ssh: Could not resolve hostname ansible_user=ubuntu: Name or service not known\r\n", "unreachable": true}
```