### PR TITLE
Prevent deployment ID from changing every plan

### DIFF
--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -1,9 +1,11 @@
 resource "random_uuid" "cluster" {}
 
+resource "time_static" "timestamp" {}
+
 locals {
-  timestamp = timestamp()
   uuid = random_uuid.cluster.result
-  deployment_id = "redpanda-${random_uuid.cluster.result}-${local.timestamp}"
+  timestamp = time_static.timestamp.rfc3339
+  deployment_id = "redpanda-${local.uuid}-${local.timestamp}"
 }
 
 resource "aws_instance" "redpanda" {


### PR DESCRIPTION
The use of timestamp() as part of the deployment ID means that,
in effect, the deployment ID changes every time a plan is created.
Instead, we use time_static, which is the recommended way to
introduce timestamps into a resouce: the timestamp is genenated only
when the resource is created in the first place.

Fixes #42.