### PR TITLE
Add time to the providers list

### DIFF
--- a/aws/provider.tf
+++ b/aws/provider.tf
@@ -4,13 +4,17 @@ terraform {
       source  = "hashicorp/aws"
       version = "3.29.1"
     }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.1.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "3.1.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = "2.1.0"
+    time = {
+      source = "hashicorp/time"
+      version = "0.7.2"
     }
   }
 }


### PR DESCRIPTION
In my last change, I forgot to add the "time" provider to the
provider.tf list. This still works because terraform also has
an autodetect mode for providers, but the recommended way is
to use this file.

Also sorted the providers list to keep merge conflicts to a minimum
in the future.