### PR TITLE
use bool filter to coerce boolean vars

### DIFF
--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -11,7 +11,7 @@
       - restart redpanda-tuner
       - restart redpanda
     vars:
-      use_public_ips: "{{ advertise_public_ips | default(false, true) }}"
+      use_public_ips: "{{ advertise_public_ips | d() | bool }}"
     shell: |
       rpk config set cluster_id 'redpanda'
       rpk config set organization 'redpanda-test'


### PR DESCRIPTION
Using:

var | d() | bool

Handles the usual cases where we set var on the command line using
string values, and also handles correctly typed values (e.g., if
var actually is a boolean).

Fixes #50.