### PR TITLE
Enable Kafka queue depth control by default

### DIFF
--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -29,6 +29,12 @@
       }' --format yaml
       sudo rpk mode production
 
+      sudo rpk config set redpanda.kafka_qdc_enable true
+      sudo rpk config set redpanda.kafka_qdc_idle_depth 8
+      sudo rpk config set redpanda.kafka_qdc_max_depth 32
+      sudo rpk config set redpanda.kafka_qdc_max_latency_ms 4
+      sudo rpk config set redpanda.rpc_server_tcp_recv_buf 65536
+
       {% if hostvars[groups['redpanda'][0]].id == hostvars[inventory_hostname].id %}
       sudo rpk config bootstrap \
         --id {{ hostvars[inventory_hostname].id }} \


### PR DESCRIPTION
Enabling Kafka queue depth controls significantly help reduce producer ack latency when disks reach write saturation. This is especially prevalent for cloud deployments with persistent remote storage because of lower iops and bandwidth.